### PR TITLE
Implement waiver form with email and Google Drive storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "react-swipeable": "^7.0.2",
     "rehype-raw": "^7.0.0",
     "rehype-sanitize": "^6.0.0",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "nodemailer": "^6.9.11",
+    "googleapis": "^133.0.0"
   },
   "devDependencies": {
     "@types/node": "22.15.18",

--- a/pages/api/waiver.ts
+++ b/pages/api/waiver.ts
@@ -1,0 +1,80 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import nodemailer from 'nodemailer';
+import { google } from 'googleapis';
+
+interface WaiverBody {
+  name: string;
+  email: string;
+  phone?: string;
+  signature: string;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  const { name, email, phone, signature } = req.body as WaiverBody;
+  if (!name || !email || !signature) {
+    return res.status(400).json({ error: 'Missing required fields' });
+  }
+
+  const waiverText = `FL Best Trainer Liability Waiver\n\nName: ${name}\nEmail: ${email}\nPhone: ${phone || ''}\nSignature: ${signature}\nDate: ${new Date().toLocaleDateString()}`;
+
+  try {
+    const transporter = nodemailer.createTransport({
+      service: 'gmail',
+      auth: {
+        user: process.env.GMAIL_USER,
+        pass: process.env.GMAIL_PASS,
+      },
+    });
+
+    await transporter.sendMail({
+      from: process.env.GMAIL_USER,
+      to: process.env.GMAIL_USER,
+      subject: `New Waiver from ${name}`,
+      text: waiverText,
+    });
+
+    await transporter.sendMail({
+      from: process.env.GMAIL_USER,
+      to: email,
+      subject: 'Copy of your FL Best Trainer waiver',
+      text: waiverText,
+    });
+
+    if (
+      process.env.GDRIVE_CLIENT_EMAIL &&
+      process.env.GDRIVE_PRIVATE_KEY &&
+      process.env.GDRIVE_FOLDER_ID
+    ) {
+      const auth = new google.auth.JWT(
+        process.env.GDRIVE_CLIENT_EMAIL,
+        undefined,
+        process.env.GDRIVE_PRIVATE_KEY.replace(/\\n/g, '\n'),
+        ['https://www.googleapis.com/auth/drive.file']
+      );
+      const drive = google.drive({ version: 'v3', auth });
+      await drive.files.create({
+        requestBody: {
+          name: `waiver_${Date.now()}.txt`,
+          parents: [process.env.GDRIVE_FOLDER_ID],
+        },
+        media: {
+          mimeType: 'text/plain',
+          body: waiverText,
+        },
+      });
+    }
+
+    return res.status(200).json({ success: true });
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: 'Failed to submit waiver' });
+  }
+}

--- a/pages/waiver.tsx
+++ b/pages/waiver.tsx
@@ -1,8 +1,10 @@
 import Layout from "@/components/shared/Layout";
 import SEO from "@/components/shared/SEO";
 import Link from "next/link";
+import { useState } from "react";
 
 export default function WaiverPage() {
+  const [submitted, setSubmitted] = useState(false);
   return (
     <Layout>
       <SEO
@@ -78,6 +80,110 @@ export default function WaiverPage() {
               beginning any training program.
             </p>
           </div>
+
+          <form
+            id="waiver-form"
+            className="space-y-6 mt-8"
+            onSubmit={async (e) => {
+              e.preventDefault();
+              const form = e.currentTarget as HTMLFormElement;
+              const data = {
+                name: (form.elements.namedItem('name') as HTMLInputElement).value,
+                email: (form.elements.namedItem('email') as HTMLInputElement).value,
+                phone: (form.elements.namedItem('phone') as HTMLInputElement).value,
+                signature: (form.elements.namedItem('signature') as HTMLInputElement).value,
+              };
+              const res = await fetch('/api/waiver', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data),
+              });
+              if (res.ok) {
+                setSubmitted(true);
+                form.reset();
+              } else {
+                alert('Failed to submit waiver.');
+              }
+            }}
+          >
+            <div>
+              <label className="block text-sm font-medium text-white mb-1" htmlFor="name">
+                Full Name
+              </label>
+              <input
+                type="text"
+                name="name"
+                id="name"
+                required
+                className="w-full rounded-md bg-white/10 border border-white/20 p-2 text-white"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-white mb-1" htmlFor="email">
+                Email Address
+              </label>
+              <input
+                type="email"
+                name="email"
+                id="email"
+                required
+                className="w-full rounded-md bg-white/10 border border-white/20 p-2 text-white"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-white mb-1" htmlFor="phone">
+                Phone Number (optional)
+              </label>
+              <input
+                type="tel"
+                name="phone"
+                id="phone"
+                className="w-full rounded-md bg-white/10 border border-white/20 p-2 text-white"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-white mb-1" htmlFor="signature">
+                Electronic Signature
+              </label>
+              <input
+                type="text"
+                name="signature"
+                id="signature"
+                required
+                className="w-full rounded-md bg-white/10 border border-white/20 p-2 text-white"
+              />
+              <p className="text-xs text-white/60 mt-1">
+                Typing your name serves as your legal signature.
+              </p>
+            </div>
+
+            <div className="flex items-center">
+              <input
+                id="agree"
+                name="agree"
+                type="checkbox"
+                required
+                className="h-4 w-4 text-royal focus:ring-royal-light border-white/20 rounded mr-2"
+              />
+              <label htmlFor="agree" className="text-white text-sm">
+                I agree to the terms above and acknowledge this electronic signature.
+              </label>
+            </div>
+
+            <button
+              type="submit"
+              className="bg-royal hover:bg-royal-light text-white font-medium py-2 px-4 rounded"
+            >
+              Submit Waiver
+            </button>
+
+            {submitted && (
+              <p className="text-green-400 mt-4">Waiver submitted successfully.</p>
+            )}
+          </form>
 
           <div className="mt-12 border-t border-white/10 pt-8">
             <Link


### PR DESCRIPTION
## Summary
- add dependencies for email and Google Drive integration
- create `/api/waiver` to send confirmation emails and upload to Google Drive
- enhance waiver page with a legal waiver form

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68699a750d08832487a48ac6a4e7fdef